### PR TITLE
Update for newer Crystals

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: v0.8.1
 authors:
   - William Woodruff <william@tuffbizz.com>
 
-crystal: 0.24.1
+crystal: ">= 0.35.0"
 
 license: MIT with restrictions

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -15,5 +15,5 @@ def dummy_window(*, activate = false, focus = false, &block)
     yield itself, proc
   end
 ensure
-  proc.kill if proc && proc.exists?
+  proc.terminate if proc && proc.exists?
 end


### PR DESCRIPTION
Currently, this shard cannot be installed on Crystal 1.0.0 without `shards` throwing a fit. The library itself works fine under newer Crystal, but one of the spec helpers used now-removed methods on `Process`.

This PR updates `shard.yml` and fixes the spec helper such that it now runs and passes.