### PR TITLE
Fix null pointer in window.name

### DIFF
--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name) if ! name.null?
+    String.new(name) unless name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name)
+    String.new(name) if ! name.null?
   end
 end


### PR DESCRIPTION
Most X11 windows apparently have no name, and xdotool (done with version 2016, the previous / working one) returns a null pointer. x_do.cr however expects a string. This adds a null check so that `window.name` returns `nil` in that case instead of failing with `Unhandled exception: Cannot create a string with a null pointer (ArgumentError)`.

Demo code:
```crystal
require "x_do"

XDo.act do
	wins = search do
		window_name "" # all (regex)
	end
	puts wins.map &.name
end
```