### PR TITLE
Get window by

### DIFF
--- a/spec/x_do_spec.cr
+++ b/spec/x_do_spec.cr
@@ -158,6 +158,33 @@ describe XDo do
     end
   end
 
+  describe "#get_window" do
+    it "returns the window" do
+      dummy_window activate: true do |xdo|
+        active_window = xdo.active_window
+        win = xdo.get_window(active_window.window)
+        active_window.should eq(win)
+      end
+    end
+
+    it "returns nil for a bad window id" do
+      large_id = 0_u64 &- 1
+      XDo.act do
+        win = get_window(large_id)
+        win.should be_nil
+      end
+    end
+
+    it "yields the window in block form" do
+      dummy_window activate: true do |xdo|
+        active_window = xdo.active_window
+        xdo.get_window active_window.window do |win|
+          active_window.should eq(win)
+        end
+      end
+    end
+  end
+
   pending "sets and retrieves the number of desktops" do
     XDo.act do
       itself.desktops = 3

--- a/src/x_do.cr
+++ b/src/x_do.cr
@@ -239,6 +239,22 @@ class XDo
     search(query)
   end
 
+  # Returns the `Window` corresponding to the *id* or `nil` if it doesn't exist.
+  def get_window(id : UInt64)
+    window = Window.new(xdo_p, id)
+    # libxdo does not override the default error handler and so a BadWindow
+    # would kill the entire process
+    old_event_handler = X11.set_error_handler ->(display : LibXDo::Display, error_event : X11::ErrorEvent*) {0}
+    name = window.name
+    X11.set_error_handler old_event_handler
+    name.nil? ? nil : window
+  end
+
+  # :ditto:
+  def get_window(id : UInt64, &block)
+    yield get_window(id)
+  end
+
   # Sets the number of desktops.
   def desktops=(ndesktops)
     LibXDo.set_number_of_desktops(xdo_p, ndesktops)

--- a/src/x_do/libxdo.cr
+++ b/src/x_do/libxdo.cr
@@ -1,4 +1,19 @@
 class XDo
+  @[Link("X11")]
+  lib X11
+    struct ErrorEvent
+      type : Int32
+      display : LibXDo::Display
+      resourceid : LibXDo::XID
+      serial : UInt64
+      error_code : UInt8
+      request_code : UInt8
+      minor_code : UInt8
+    end
+    alias ErrorHandler = LibXDo::Display, ErrorEvent* -> Int32
+    fun set_error_handler = XSetErrorHandler(handler : ErrorHandler) : ErrorHandler
+  end
+
   @[Link("xdo")]
   lib LibXDo
     enum Status

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name) if ! name.null?
+    String.new(name) unless name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name)
+    String.new(name) if ! name.null?
   end
 end


### PR DESCRIPTION
closes #13

> Just to clarify: is there a libxdo API for getting (and validating) a window by WID

It looks like there is none.

> , or are you proposing that x_do.cr add a separate API for that that uses Xlib directly?

Yes - I tried doing that in this PR. However, you cannot simply do

```crystal
win = Window.new(xdo_p, id)
begin
  win.name
rescue
  nil
```
because when `id` is invalid, xdotool does not catch the X11 error and that kills the *entire process*... so I think the only way is to temporarily override the default X11 error handler like I did. Unless I missed something?

I think this approach is horrible and suggest this experiment should not be merged and closed instead. I wanted to share it anyway.

Another downside is that binding to `XSetErrorHandler` can conflict with other libraries that do similar stuff. It most likely fails to build in conjunction with https://github.com/TamasSzekeres/x11-cr but I haven't tested.