### PR TITLE
Fix `window.pid` return value

### DIFF
--- a/src/x_do/libxdo.cr
+++ b/src/x_do/libxdo.cr
@@ -150,7 +150,7 @@ class XDo
     fun raise_window = xdo_raise_window(xdo : XDo*, wid : Window) : Status
     fun get_focused_window = xdo_get_focused_window(xdo : XDo*, window_ret : Window*) : Status
     fun wait_for_window_focus = xdo_wait_for_window_focus(xdo : XDo*, window : Window, want_focus : LibC::Int) : Status
-    fun get_pid_window = xdo_get_pid_window(xdo : XDo*, window : Window) : Status
+    fun get_pid_window = xdo_get_pid_window(xdo : XDo*, window : Window) : LibC::Int
     fun get_focused_window_sane = xdo_get_focused_window_sane(xdo : XDo*, window_ret : Window*) : Status
     fun activate_window = xdo_activate_window(xdo : XDo*, wid : Window) : Status
     fun wait_for_window_active = xdo_wait_for_window_active(xdo : XDo*, window : Window, active : LibC::Int) : Status

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name) if ! name.null?
+    String.new(name) unless name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name)
+    String.new(name) if ! name.null?
   end
 end


### PR DESCRIPTION
PID (or 0) instead of Success/Error.

The reason the test is failing (so I still haven't activated it) is that `xlogo` is apparently a magic window:

    $ xdotool search --name xlogo getwindowpid
    > window 117440513 has no pid associated with it.

I have verified the functionality manually instead.