### PR TITLE
Add global click type actions

### DIFF
--- a/spec/x_do_spec.cr
+++ b/spec/x_do_spec.cr
@@ -183,4 +183,28 @@ describe XDo do
 
   pending "sets, retrieves, and checks xdo features" do
   end
+
+  pending "#mouse_down" do
+  end
+
+  pending "#mouse_up" do
+  end
+
+  pending "#click" do
+  end
+
+  pending "#click" do
+  end
+
+  pending "#type" do
+  end
+
+  pending "#keys" do
+  end
+
+  pending "#keys_down" do
+  end
+
+  pending "#keys_up" do
+  end
 end

--- a/src/x_do.cr
+++ b/src/x_do.cr
@@ -304,4 +304,62 @@ class XDo
   def has_feature?(feature : XDoFeatures)
     LibXDo.has_feature(xdo_p, feature) == 1
   end
+
+  # Send a mouse-down event for the given mouse *button* to the active window.
+  def mouse_down(button : Button)
+    LibXDo.mouse_down(xdo_p, 0, button)
+  end
+
+  # Send a mouse-up event for the given mouse *button* to the active window.
+  def mouse_up(button : Button)
+    LibXDo.mouse_up(xdo_p, 0, button)
+  end
+
+  # Click the given mouse *button* on the active window (mouse-down + mouse-up)
+  def click(button : Button)
+    LibXDo.click_window(xdo_p, 0, button)
+  end
+
+  # Click the given mouse *button* *repeat* times, with *delay* between each click.
+  def click(button : Button, repeat, delay = DEFAULT_DELAY)
+    LibXDo.click_window_multiple(xdo_p, 0, button, repeat, delay)
+  end
+
+  # Send some *text* to the active window, with *delay* between the keystrokes.
+  #
+  # ```
+  # type "hello from Crystal!"
+  # ```
+  def type(text : String, delay = DEFAULT_DELAY)
+    LibXDo.enter_text_window(xdo_p, 0, text, delay)
+  end
+
+  # Send some *keys* (down + up) to the active window, with *delay* between them.
+  #
+  # ```
+  # keys "Ctrl+s"
+  # ```
+  def keys(keys : String, delay = DEFAULT_DELAY)
+    LibXDo.send_keysequence_window(xdo_p, 0, keys, delay)
+  end
+
+  # Send some key press (down) events for the given *keys*, with *delay* between them.
+  # See `#keys_up`.
+  #
+  # ```
+  # keys_down "Ctrl+o"
+  # ```
+  def keys_down(keys : String, delay = DEFAULT_DELAY)
+    LibXDo.send_keysequence_window_down(xdo_p, 0, keys, delay)
+  end
+
+  # Send some key release (up) events for the given *keys*, with *delay* between them.
+  # See `#keys_down`.
+  #
+  # ```
+  # keys_up "Ctrl+o"
+  # ```
+  def keys_up(keys : String, delay = DEFAULT_DELAY)
+    LibXDo.send_keysequence_window_up(xdo_p, 0, keys, delay)
+  end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name) if ! name.null?
+    String.new(name) unless name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name)
+    String.new(name) if ! name.null?
   end
 end


### PR DESCRIPTION
These are sent to the active window and perform more reliably than the window-specific calls, just like in xdotool
Fixes #12

I guess these could also be externalized since they are very similar to the ones in `window.cr`, if you want that. But the docs are somewhat modified and I personally thought it was cleaner this way