### PR TITLE
x_do: Add `keys_raw`

### DIFF
--- a/spec/window_spec.cr
+++ b/spec/window_spec.cr
@@ -79,6 +79,9 @@ describe XDo::Window do
   pending "#keys_up" do
   end
 
+  pending "#keys_raw" do
+  end
+
   pending "#move" do
   end
 

--- a/spec/x_do_spec.cr
+++ b/spec/x_do_spec.cr
@@ -207,4 +207,7 @@ describe XDo do
 
   pending "#keys_up" do
   end
+
+  pending "#keys_raw" do
+  end
 end

--- a/src/x_do.cr
+++ b/src/x_do.cr
@@ -362,4 +362,24 @@ class XDo
   def keys_up(keys : String, delay = DEFAULT_DELAY)
     LibXDo.send_keysequence_window_up(xdo_p, 0, keys, delay)
   end
+
+  # Send some key events by specifying keysyms and modifiers directly,
+  # with *delay* between them.
+  # You most likely want to use `#keys` or `#type` instead, however this function
+  # skips the string parsing and should consequently run slightly faster.
+  #
+  # ```
+  # key1 = XDo::LibXDo::Charcodemap.new
+  # key1.code = 38
+  # key1.modmask = 1
+  # key2 = XDo::LibXDo::Charcodemap.new
+  # key2.code = 56
+  # keys = [key1, key2]
+  # # Sends `AB`
+  # keys_raw keys, pressed: true
+  # keys_raw keys, pressed: false
+  # ```
+  def keys_raw(keys : Array(LibXDo::Charcodemap), *, pressed : Bool, modifier = 0, delay = DEFAULT_DELAY)
+    LibXDo.send_keysequence_window_list_do(xdo_p, 0, keys, keys.size, pressed, pointerof(modifier), delay)
+  end
 end

--- a/src/x_do/libxdo.cr
+++ b/src/x_do/libxdo.cr
@@ -116,7 +116,6 @@ class XDo
     fun new_with_opened_display = xdo_new_with_opened_display(xdpy : Display, display : LibC::Char*, close_display_when_freed : LibC::Int) : XDo*
 
     # TODO: Unimplemented (probably not useful to 99% of users).
-    fun send_keysequence_window_list_do = xdo_send_keysequence_window_list_do(xdo : XDo*, window : Window, keys : Charcodemap*, nkeys : LibC::Int, pressed : LibC::Int, modifier : LibC::Int*, delay : UsecondsT) : Status
     fun get_window_property_by_atom = xdo_get_window_property_by_atom(xdo : XDo*, window : Window, atom : Atom, nitems : LibC::Long*, type : Atom*, size : LibC::Int*) : UInt8*
 
     fun new = xdo_new(display : LibC::Char*) : XDo*
@@ -137,6 +136,7 @@ class XDo
     fun send_keysequence_window = xdo_send_keysequence_window(xdo : XDo*, window : Window, keysequence : LibC::Char*, delay : UsecondsT) : Status
     fun send_keysequence_window_up = xdo_send_keysequence_window_up(xdo : XDo*, window : Window, keysequence : LibC::Char*, delay : UsecondsT) : Status
     fun send_keysequence_window_down = xdo_send_keysequence_window_down(xdo : XDo*, window : Window, keysequence : LibC::Char*, delay : UsecondsT) : Status
+    fun send_keysequence_window_list_do = xdo_send_keysequence_window_list_do(xdo : XDo*, window : Window, keys : Charcodemap*, nkeys : LibC::Int, pressed : LibC::Int, modifier : LibC::Int*, delay : UsecondsT) : Status
     fun wait_for_window_map_state = xdo_wait_for_window_map_state(xdo : XDo*, wid : Window, map_state : LibC::Int) : Status
     fun wait_for_window_size = xdo_wait_for_window_size(xdo : XDo*, window : Window, width : LibC::UInt, height : LibC::UInt, flags : LibC::Int, to_or_from : LibC::Int) : Status
     fun move_window = xdo_move_window(xdo : XDo*, wid : Window, x : LibC::Int, y : LibC::Int) : Status

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name) if ! name.null?
+    String.new(name) unless name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -366,6 +366,6 @@ class XDo::Window
   # Get the window's name (`WM_NAME`), if any.
   def name
     LibXDo.get_window_name(xdo_p, window, out name, out _, out _)
-    String.new(name)
+    String.new(name) if ! name.null?
   end
 end

--- a/src/x_do/window.cr
+++ b/src/x_do/window.cr
@@ -155,6 +155,26 @@ class XDo::Window
     LibXDo.send_keysequence_window_up(xdo_p, window, keys, delay)
   end
 
+  # Send some key events by specifying keysyms and modifiers directly,
+  # with *delay* between them.
+  # You most likely want to use `#keys` or `#type` instead, however this function
+  # skips the string parsing and should consequently run slightly faster.
+  #
+  # ```
+  # key1 = XDo::LibXDo::Charcodemap.new
+  # key1.code = 38
+  # key1.modmask = 1
+  # key2 = XDo::LibXDo::Charcodemap.new
+  # key2.code = 56
+  # keys = [key1, key2]
+  # # Sends `AB`
+  # win.keys_raw keys, pressed: true
+  # win.keys_raw keys, pressed: false
+  # ```
+  def keys_raw(keys : Array(LibXDo::Charcodemap), *, pressed : Bool, modifier = 0, delay = DEFAULT_DELAY)
+    LibXDo.send_keysequence_window_list_do(xdo_p, window, keys, keys.size, pressed, pointerof(modifier), delay)
+  end
+
   # Attempt to move the window to *x*, *y* on the screen.
   #
   # ```


### PR DESCRIPTION
both for window and global

This adds support for the so far unsupported `xdo_send_keysequence_window_list_do`, with which you can send fine-tuned modifiers, key codes, delays etc.